### PR TITLE
typo: pip install from github had incorrect URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install from Pypi with:
 pip install shiny_validate
 ```
 
-Or, you can install the latest development version from GitHub using the `remotes` package.
+Or, you can install the latest development version from GitHub:
 
 ```
 pip install git+https://github.com/posit-dev/py-shiny-validate.git

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ pip install shiny_validate
 Or, you can install the latest development version from GitHub using the `remotes` package.
 
 ```
-pip install git+https://github.com/rstudio/shinyvalidate.git
-
+pip install git+https://github.com/posit-dev/py-shiny-validate.git
 ```
 
 ## Basic usage


### PR DESCRIPTION
Hi Gordon!

Thanks so much for your work on this, this has been incredibly helpful for me.

I noticed that the URL for pip installing was pointing to the R implementation, and just went ahead and corrected that.